### PR TITLE
fix: allow null audit messages in API responses

### DIFF
--- a/cdk/src/rest-api/resources/app/resources/objects/schema.test.ts
+++ b/cdk/src/rest-api/resources/app/resources/objects/schema.test.ts
@@ -183,6 +183,28 @@ describe("objects handler schemas", () => {
       expect(result.data?.pagination?.nextToken).toBe("next-page");
     });
 
+    it("should validate audit items with null messages as undefined", () => {
+      const result = ResponseCollectionSchema.safeParse({
+        items: [
+          {
+            id: "audit-456",
+            status: "success",
+            tier: 2,
+            operation: "createItem",
+            target: {
+              app: App.App1,
+              type: ResourceType.UNKNOWN,
+              id: "item-123",
+            },
+            message: null,
+          },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.items[0].message).toBeUndefined();
+    });
+
     it("should reject response without items array", () => {
       const result = ResponseCollectionSchema.safeParse({});
       expect(result.success).toBe(false);
@@ -238,6 +260,24 @@ describe("objects handler schemas", () => {
         "detail-type": "TestEvent",
         detail: '{"id":"item-123"}',
       });
+    });
+
+    it("should validate detail responses with null messages as undefined", () => {
+      const result = ResponseDetailSchema.safeParse({
+        id: "audit-456",
+        status: "success",
+        tier: 2,
+        operation: "createItem",
+        target: {
+          app: App.App1,
+          type: ResourceType.UNKNOWN,
+          id: "item-123",
+        },
+        message: null,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.message).toBeUndefined();
     });
   });
 });

--- a/sdk/src/schema/audit.test.ts
+++ b/sdk/src/schema/audit.test.ts
@@ -51,6 +51,21 @@ describe("AuditSchema", () => {
     expect(result.updatedAt).toBeInstanceOf(Date);
     expect(result.createdAt).toBeInstanceOf(Date);
   });
+
+  it("should convert null messages from stored audit items to undefined", () => {
+    const result = AuditSchema.parse({
+      id: "audit-123",
+      operation: "testOp",
+      status: "success",
+      tier: 2,
+      target: createValidTarget(),
+      message: null,
+      updatedAt: "2024-01-15T10:30:00.000Z",
+      createdAt: "2024-01-15T10:30:00.000Z",
+    });
+
+    expect(result.message).toBeUndefined();
+  });
 });
 
 describe("AuditPayloadSchema", () => {
@@ -83,5 +98,18 @@ describe("AuditPayloadSchema", () => {
       "detail-type": "TestEvent",
       detail: '{"id":"item-123"}',
     });
+  });
+
+  it("should convert null messages in JSON response payloads to undefined", () => {
+    const result = AuditPayloadSchema.parse({
+      id: "audit-123",
+      operation: "testOp",
+      status: "success",
+      tier: 2,
+      target: createValidTarget(),
+      message: null,
+    });
+
+    expect(result.message).toBeUndefined();
   });
 });

--- a/sdk/src/schema/common.ts
+++ b/sdk/src/schema/common.ts
@@ -157,7 +157,10 @@ export const BaseSchema = z.object({
   /** Name of the operation being audited */
   operation: z.string(),
   /** Human-readable description of the audit */
-  message: z.string().optional(),
+  message: z
+    .union([z.string(), z.null()])
+    .optional()
+    .transform((value) => value ?? undefined),
   /** Whether this audit can be re-run/retried */
   rerunable: z.boolean().optional(),
   /** Trace identifier for distributed tracing */


### PR DESCRIPTION
## Summary
- accept `message: null` in shared audit schemas and normalize it to `undefined`
- add SDK schema coverage for stored audit records and JSON payloads
- add REST API response schema coverage for collection and detail responses

## Tests
- `pnpm test`
- `pnpm check`
- `pnpm build`

Closes #68